### PR TITLE
Removed opengraph

### DIFF
--- a/views/404/index.ejs
+++ b/views/404/index.ejs
@@ -3,12 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <title>Zytekaron - 404</title>
-    <%- render.template('opengraph', {
-        title: '404 - Not Found',
-        desc: 'That page doesn\'t exist on this site.',
-        url: 'https://zytekaron.com/',
-        image: 'https://cdn.discordapp.com/avatars/272659147974115328/4ff07692fab03809e7754fa160a77155.png'
-    }) %>
     <%- render.template('head') %>
     <%- render.css('404') %>
 </head>


### PR DESCRIPTION
Open graph is not required for 404 pages. It will cause the page to be indexed by Google, even though it's not supposed to be.